### PR TITLE
fix(micro): 修改eventbus声明位置

### DIFF
--- a/packages/hel-micro/src/user-util/preFetch.ts
+++ b/packages/hel-micro/src/user-util/preFetch.ts
@@ -17,8 +17,6 @@ import type {
   VersionId,
 } from '../types';
 
-const eventBus = getHelEventBus();
-
 type LoadAssetsStarter = (() => void) | null;
 
 function makePreFetchOptions(isLib: boolean, options?: IPreFetchLibOptions | VersionId) {
@@ -29,6 +27,8 @@ function makePreFetchOptions(isLib: boolean, options?: IPreFetchLibOptions | Ver
 }
 
 async function waitAppEmit(appName: string, innerOptions: IInnerPreFetchOptions, loadAssetsStarter?: LoadAssetsStarter) {
+  const eventBus = getHelEventBus();
+
   const { platform, isLib = false, versionId, projectId, strictMatchVer } = innerOptions;
   const eventName = isLib ? helEvents.SUB_LIB_LOADED : helEvents.SUB_APP_LOADED;
 


### PR DESCRIPTION
修改`eventbus` 声明位置，保证`resetGlobalThis`重置`globalThis`后获取到的`eventbus`是当前环境的`eventbus`对象，防止`resetGlobalThis`后 `on`函数无法响应`emit`函数事件