### PR TITLE
fix(proxy,core): exposeLib函数添加versionId参数

### DIFF
--- a/packages/hel-lib-proxy/src/index.ts
+++ b/packages/hel-lib-proxy/src/index.ts
@@ -51,7 +51,7 @@ export function getLib<T extends any>(libName: LibName, getOptions?: IGetOptions
  * @param options
  * @returns
  */
-export function exposeLib<L extends LibProperties>(libName: string, options?: IExposeLibOptions | Platform): L {
+export function exposeLib<L extends LibProperties>(libName: string, versionId: string, options?: IExposeLibOptions | Platform): L {
   let asProxy = true;
   let platform = '';
   if (options) {
@@ -64,9 +64,9 @@ export function exposeLib<L extends LibProperties>(libName: string, options?: IE
   }
   platform = platform || diff.getDefaultPlatform();
 
-  let libObj = share.getLibObj<L>(libName, platform);
+  let libObj = share.getLibObj<L>(libName, versionId, platform);
   if (typeof Proxy === 'function' && asProxy) {
-    libObj = share.getLibProxy(libName, libObj, platform);
+    libObj = share.getLibProxy(libName, libObj, versionId, platform);
   }
   core.log('[[ exposeLib ]] libName, libObj', libName, libObj);
   return libObj;

--- a/packages/hel-lib-proxy/src/share.ts
+++ b/packages/hel-lib-proxy/src/share.ts
@@ -17,17 +17,20 @@ export function getMergedOptions(options?: IOptions) {
  * @param platform
  * @returns
  */
-export function getLibObj<L extends LibProperties>(libName: string, platform?: Platform): L {
+export function getLibObj<L extends LibProperties>(libName: string, versionId: string, platform?: Platform): L {
   // 使用 getAppPlatform?.是为了 防止 peerDependencies 里用户还未升级最新版 hel-micro-core
   const platformVar = platform || getAppPlatform?.(libName);
   const appName2Lib = getSharedCache(platformVar).appName2Lib;
   if (!appName2Lib[libName]) {
     appName2Lib[libName] = {};
   }
-  return appName2Lib[libName] as L;
+  if (!appName2Lib[libName][versionId]) {
+    appName2Lib[libName][versionId] = {};
+  }
+  return appName2Lib[libName][versionId] as L;
 }
 
-export function getLibProxy<L extends LibProperties>(libName: string, libObj: L, platform?: Platform): L {
+export function getLibProxy<L extends LibProperties>(libName: string, libObj: L, versionId: string, platform?: Platform): L {
   return new Proxy(libObj, {
     get(target, key) {
       const strKey = String(key);
@@ -36,7 +39,7 @@ export function getLibProxy<L extends LibProperties>(libName: string, libObj: L,
         return target[strKey];
       }
       // 支持 resetGlobalThis 后，也能够安全获取到模块
-      const safeTarget = getLibObj(libName, platform);
+      const safeTarget = getLibObj(libName, versionId, platform);
       return safeTarget[strKey];
     },
   });


### PR DESCRIPTION
**Warning: 属于breaking change**

意图：为exposeLib函数添加versionId参数，保证在同一js环境下多版本导入与多项目使用静态导入时能够获取到相应版本的proxy模块。

Tips：需要修改文档中模板示例 `hel-tpl-remote-lib` 中的 `libTypes.ts`中的`exposeLib` 函数添加`version`参数

`import { version } from '../../package.json'; `
`export const lib = exposeLib<LibProperties>(LIB_NAME, version);`